### PR TITLE
jcanotorr06/feat/landing_tabs

### DIFF
--- a/src/components/Landing/ToolCard.tsx
+++ b/src/components/Landing/ToolCard.tsx
@@ -1,0 +1,29 @@
+import { type FC } from 'react'
+import Link from 'next/link'
+
+type Props = {
+    name: string,
+    description: string,
+    category: string,
+    link: string
+}
+
+const ToolCard:FC<Props> = (props:Props) => {
+    const { name, description, category, link } = props
+
+    return (
+        <article className="rounded-lg col-span-full lg:col-span-6 xl:col-span-3 row-span-1 p-4 bg-base-100 shadow-md grid grid-cols-4 grid-rows-3">
+            <div className="col-span-4 row-span-2 gap-2">
+                <h2 className="text-lg font-semibold">{name}</h2>
+                <p>{description}</p>
+            </div>
+            <div className="col-span-4 row-span-1">
+                <Link href={`${category}/${link}`} className="btn btn-primary rounded-lg w-full">
+                    <span>Use</span>
+                </Link>
+            </div>
+        </article>
+    )
+}
+
+export default ToolCard

--- a/src/components/Landing/index.ts
+++ b/src/components/Landing/index.ts
@@ -1,0 +1,1 @@
+export { default as ToolCard } from './ToolCard';

--- a/src/components/Navigation/Sidebar.tsx
+++ b/src/components/Navigation/Sidebar.tsx
@@ -54,7 +54,7 @@ const Sidebar:FC = () => {
             </label>
             {routes.map((route, index) => (
                 <Link href={route.path} key={index} className="w-full">
-                    <div className={`btn btn-primary ${router.asPath !== route.path && "btn-outline"} rounded w-full`}>
+                    <div className={`btn btn-primary ${router.pathname !== route.path && "btn-outline"} rounded w-full`}>
                         {route.icon}
                         &nbsp;
                         <AnimatePresence>

--- a/src/pages/generators/email.tsx
+++ b/src/pages/generators/email.tsx
@@ -2,14 +2,16 @@ import { type NextPage } from "next";
 import { NextSeo } from "next-seo";
 import { Fragment } from "react";
 import { MessageDetails, Address, Inbox } from "../../components/Email";
+import tools from "../../utils/tools";
 
 const Email:NextPage = () => {
+    const tool = tools.find(tool => tool.id === "email")
 
     return (
         <Fragment>
             <NextSeo
-                title="Temporary Email Generator | Dev Toolbox"
-                description="Genereate a disposable temporary email address."
+                title={`${tool?.name} | Dev Toolbox`}
+                description={tool?.description}
             />
             <main className="grid gap-4 grid-flow-row grid-cols-1 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-12 grid-rows-6 w-full">
                 <section className="col-span-5 row-span-1 flex flex-col gap-4 rounded-lg bg-base-100 p-4 shadow-md">

--- a/src/pages/generators/email.tsx
+++ b/src/pages/generators/email.tsx
@@ -8,8 +8,8 @@ const Email:NextPage = () => {
     return (
         <Fragment>
             <NextSeo
-                title="Temporary Email | Dev Toolbox"
-                description="Disposable Temporary Email Address"
+                title="Temporary Email Generator | Dev Toolbox"
+                description="Genereate a disposable temporary email address."
             />
             <main className="grid gap-4 grid-flow-row grid-cols-1 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-12 grid-rows-6 w-full">
                 <section className="col-span-5 row-span-1 flex flex-col gap-4 rounded-lg bg-base-100 p-4 shadow-md">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,53 +1,77 @@
 import { type NextPage } from "next";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { ToolCard } from "../components/Landing";
 
 const Home: NextPage = () => {
+
+  const router = useRouter()
+
+  const tabs = [
+    { name: "All", query: "" },
+    { name: "Formatters", query: "formatters" },
+    { name: "Converters", query: "converters" },
+    { name: "Generators", query: "generators" },
+    { name: "Validators", query: "validators" },
+    { name: "Encoders", query: "encoders" },
+    { name: "Decoders", query: "decoders" },
+    { name: "Minifiers", query: "minifiers" },
+    { name: "Beautifiers", query: "beautifiers" },
+    { name: "Parsers", query: "parsers" },
+    { name: "Others", query: "others" },
+  ]
+
+  const tools = [
+    {
+      name: "Temporary Email Generator",
+      description: "Generate a disposable temporary email address.",
+      category: "generators",
+      link: "/email"
+    },
+  ]
+
+  const tabQuery = router.query.tab || ""
+
   return (
-      <main className="grid gap-4 grid-flow-row grid-cols-1 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-12 auto-rows-max w-full">
+      <main className="grid gap-4 grid-flow-row grid-cols-12 auto-rows-max w-full">
         <article className="rounded-lg col-span-12 p-4">
           <h1 className="text-2xl font-semibold">Dev Toolbox</h1>
           <p>
             Explore our collection of tools for developers, designed to help you with your daily tasks.
           </p>
         </article>
-        <article className="rounded-lg col-span-12 p-4 bg-base-100 shadow-md grid grid-flow-col gap-4 text-center font-medium max-w-full overflow-x-auto">
-          <div className="col-span-auto btn rounded">
-            Formatters
-          </div>
-          <div className="col-span-auto btn rounded btn-outline">
-            Converters
-          </div>
-          <div className="col-span-auto btn rounded btn-outline">
-            Generators
-          </div>
-          <div className="col-span-auto btn rounded btn-outline">
-            Validators
-          </div>
-          <div className="col-span-auto btn rounded btn-outline">
-            Encoders
-          </div>
-          <div className="col-span-auto btn rounded btn-outline">
-            Decoders
-          </div>
-          <div className="col-span-auto btn rounded btn-outline">
-            Minifiers
-          </div>
-          <div className="col-span-auto btn rounded btn-outline">
-            Beautifiers
-          </div>
-          <div className="col-span-auto btn rounded btn-outline">
-            Parsers
-          </div>
-          <div className="col-span-auto btn rounded btn-outline">
-            Converters
-          </div>
-          <div className="col-span-auto btn rounded btn-outline">
-            Others
-          </div>
-        </article>
+        <nav className="rounded-lg col-span-12 p-4 bg-base-100 shadow-md grid grid-flow-col gap-4 text-center font-medium max-w-full overflow-x-auto">
+          {tabs.map((tab, index) => (
+            <div
+              key={index}
+              className={`btn rounded ${tabQuery === tab.query ? "btn-primary" : "btn-outline"}`}
+              onClick={() => router.push(`/?tab=${tab.query}`)}
+            >
+              {tab.name}
+            </div>
+          ))}
+        </nav>
 
-        <article className="rounded-lg col-span-2 row-span-1 p-4 bg-base-100 shadow-md grid grid-cols-4 grid-rows-3">
-          Tool 1
-        </article>
+        {tabQuery === "" ?
+            tools.map((tool, index) => (
+              <ToolCard
+                key={index}
+                name={tool.name}
+                description={tool.description}
+                category={tool.category}
+                link={tool.link}
+              />
+            )):
+            tools.filter(tool => tool.category === tabQuery).map((tool, index) => (
+              <ToolCard
+                key={index}
+                name={tool.name}
+                description={tool.description}
+                category={tool.category}
+                link={tool.link}
+              />
+            ))
+        }
       </main>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,34 +1,12 @@
 import { type NextPage } from "next";
-import Link from "next/link";
 import { useRouter } from "next/router";
 import { ToolCard } from "../components/Landing";
+import tabs from "../utils/tabs";
+import tools from "../utils/tools";
 
 const Home: NextPage = () => {
 
   const router = useRouter()
-
-  const tabs = [
-    { name: "All", query: "" },
-    { name: "Formatters", query: "formatters" },
-    { name: "Converters", query: "converters" },
-    { name: "Generators", query: "generators" },
-    { name: "Validators", query: "validators" },
-    { name: "Encoders", query: "encoders" },
-    { name: "Decoders", query: "decoders" },
-    { name: "Minifiers", query: "minifiers" },
-    { name: "Beautifiers", query: "beautifiers" },
-    { name: "Parsers", query: "parsers" },
-    { name: "Others", query: "others" },
-  ]
-
-  const tools = [
-    {
-      name: "Temporary Email Generator",
-      description: "Generate a disposable temporary email address.",
-      category: "generators",
-      link: "/email"
-    },
-  ]
 
   const tabQuery = router.query.tab || ""
 

--- a/src/utils/tabs.ts
+++ b/src/utils/tabs.ts
@@ -1,0 +1,15 @@
+const tabs = [
+    { name: "All", query: "" },
+    { name: "Formatters", query: "formatters" },
+    { name: "Converters", query: "converters" },
+    { name: "Generators", query: "generators" },
+    { name: "Validators", query: "validators" },
+    { name: "Encoders", query: "encoders" },
+    { name: "Decoders", query: "decoders" },
+    { name: "Minifiers", query: "minifiers" },
+    { name: "Beautifiers", query: "beautifiers" },
+    { name: "Parsers", query: "parsers" },
+    { name: "Others", query: "others" },
+  ]
+
+export default tabs

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,0 +1,11 @@
+const tools = [
+    {
+      name: "Temporary Email Generator",
+      description: "Generate a disposable temporary email address.",
+      category: "generators",
+      link: "email",
+      id: "email",
+    },
+  ]
+
+export default tools


### PR DESCRIPTION
# Description

Add functionality to the tabs in the landing page by creating a list of tabs and a list of tools with the following structures:

```js
const tabs = [
   {
      name: "tab name",
      query: "tab query param"
   },
]

const tools = [
   {
      name: "tool name",
      description: "tool description",
      category: "tool category",
      link: "/tool link"
   }
]
```

Each tab has a `name`, which is used to display in the tab list and a `query`, which is used to call the router API to help filter the tools.
Each tool has a `name` and `description`, which are used to display in the cards, a `category` used to filter each tool and a `link` used to navigate to the tool's page.
Each tool page will take the tool's title and description for it's SEO metadata